### PR TITLE
Add mm2-identity-replication.jar to kafka libs dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM strimzi/kafka:0.17.0-rc1-kafka-2.4.0
 ARG JAR_FILE
 USER root:root
-COPY target/${JAR_FILE} /opt/kafka/plugins/
+COPY target/${JAR_FILE} /opt/kafka/libs/
 USER 1001


### PR DESCRIPTION
To avoid Kafka Connect treating the mm2-identity-replication.jar as a different plugin to the MirrorSourceConnector plugin, add the mm2-identity-replication.jar to kafka's libs dir.